### PR TITLE
(#4) Fix flowable not desubscribing correctly from the store when disposed

### DIFF
--- a/mini-common/src/main/java/mini/Store.kt
+++ b/mini-common/src/main/java/mini/Store.kt
@@ -21,8 +21,8 @@ abstract class Store<S> : Closeable {
         }
     }
 
+    internal val listeners = Vector<(S) -> Unit>()
     private var _state: Any? = NO_STATE
-    private val listeners = Vector<(S) -> Unit>()
 
     /** Set new state, equivalent to [asNewState]*/
     protected fun setState(state: S) {

--- a/mini-common/src/test/kotlin/mini/SampleStore.kt
+++ b/mini-common/src/test/kotlin/mini/SampleStore.kt
@@ -6,4 +6,6 @@ class SampleStore : Store<String>() {
     fun updateState(s: String) {
         newState = s
     }
+
+    val storeSubscriptions = listeners
 }

--- a/mini-rx2/build.gradle
+++ b/mini-rx2/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     implementation "io.reactivex.rxjava2:rxjava:$rx_version"
 
+    testApi files(project(":mini-common").sourceSets.test.runtimeClasspath) // Add mini-common test classes as dependency
     testCompileOnly 'junit:junit:4.12'
     testImplementation "org.amshove.kluent:kluent:1.44"
 }

--- a/mini-rx2/src/main/java/mini/rx/RxUtils.kt
+++ b/mini-rx2/src/main/java/mini/rx/RxUtils.kt
@@ -1,6 +1,7 @@
 package mini.rx
 
 import io.reactivex.BackpressureStrategy
+import io.reactivex.BackpressureStrategy.BUFFER
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
@@ -69,6 +70,5 @@ fun <S> Store<S>.observable(hotStart: Boolean = true): Observable<S> {
 }
 
 fun <S> Store<S>.flowable(hotStart: Boolean = true,
-                          backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST): Flowable<S> {
-    return observable(hotStart).toFlowable(backpressureStrategy)
-}
+                          backpressureStrategy: BackpressureStrategy = BUFFER): Flowable<S> =
+    observable(hotStart).toFlowable(backpressureStrategy)

--- a/mini-rx2/src/main/java/mini/rx/RxUtils.kt
+++ b/mini-rx2/src/main/java/mini/rx/RxUtils.kt
@@ -1,10 +1,10 @@
 package mini.rx
 
+import io.reactivex.BackpressureStrategy
 import io.reactivex.Flowable
 import io.reactivex.Observable
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.disposables.Disposable
-import io.reactivex.processors.PublishProcessor
 import io.reactivex.subjects.PublishSubject
 import mini.Store
 
@@ -57,20 +57,18 @@ class DefaultSubscriptionTracker : SubscriptionTracker {
     }
 }
 
-fun <S> Store<S>.flowable(hotStart: Boolean = true): Flowable<S> {
-    val processor = PublishProcessor.create<S>()
-    val subscription = subscribe(hotStart = false) {
-        processor.offer(it)
-    }
-    return processor.doOnTerminate { subscription.close() }
-        .let { if (hotStart) it.startWith(state) else it }
-}
-
 fun <S> Store<S>.observable(hotStart: Boolean = true): Observable<S> {
     val subject = PublishSubject.create<S>()
     val subscription = subscribe(hotStart = false) {
         subject.onNext(it)
     }
-    return subject.doOnTerminate { subscription.close() }
+    return subject
+        .doOnDispose { subscription.close() }
+        .doOnTerminate { subscription.close() }
         .let { if (hotStart) it.startWith(state) else it }
+}
+
+fun <S> Store<S>.flowable(hotStart: Boolean = true,
+                          backpressureStrategy: BackpressureStrategy = BackpressureStrategy.LATEST): Flowable<S> {
+    return observable(hotStart).toFlowable(backpressureStrategy)
 }

--- a/mini-rx2/src/test/kotlin/mini/rx/RxUtilsKtTest.kt
+++ b/mini-rx2/src/test/kotlin/mini/rx/RxUtilsKtTest.kt
@@ -1,6 +1,7 @@
 package mini.rx
 
 import mini.SampleStore
+import org.amshove.kluent.`should be empty`
 import org.amshove.kluent.`should be equal to`
 import org.junit.Test
 
@@ -28,6 +29,27 @@ class RxUtilsKtTest {
     }
 
     @Test
+    fun `flowable completes`() {
+        val store = SampleStore()
+        var sentState = ""
+        val disposable = store.flowable(hotStart = false).subscribe {
+            sentState = it
+        }
+        disposable.dispose() //Clear it
+        store.updateState("abc")
+        sentState `should be equal to` "" //No change should be made
+    }
+
+    @Test
+    fun `flowable disposes correctly`() {
+        val store = SampleStore()
+        val disposable = store.flowable(hotStart = false).subscribe()
+        disposable.dispose() //Clear it
+
+        store.storeSubscriptions.`should be empty`()
+    }
+
+    @Test
     fun `observable sends initial state`() {
         val store = SampleStore()
         store.updateState("abc") //Set before subscribe
@@ -47,5 +69,26 @@ class RxUtilsKtTest {
         }
         store.updateState("abc") //Set before subscribe
         sentState `should be equal to` "abc"
+    }
+
+    @Test
+    fun `observable completes`() {
+        val store = SampleStore()
+        var sentState = ""
+        val disposable = store.observable(hotStart = false).subscribe {
+            sentState = it
+        }
+        disposable.dispose() //Clear it
+        store.updateState("abc")
+        sentState `should be equal to` "" //No change should be made
+    }
+
+    @Test
+    fun `observable disposes correctly`() {
+        val store = SampleStore()
+        val disposable = store.observable(hotStart = false).subscribe()
+        disposable.dispose() //Clear it
+
+        store.storeSubscriptions.`should be empty`()
     }
 }

--- a/mini-rx2/src/test/kotlin/mini/rx/SampleStore.kt
+++ b/mini-rx2/src/test/kotlin/mini/rx/SampleStore.kt
@@ -1,9 +1,0 @@
-package mini
-
-class SampleStore : Store<String>() {
-    override fun initialState(): String = "initial"
-
-    fun updateState(s: String) {
-        newState = s
-    }
-}


### PR DESCRIPTION
Should fix #4 
Basically backports [minikorp/mini fix](https://github.com/minikorp/mini/issues/7) for this and adds tests to ensure that subscriptions are, in fact properly closed for both `flowable()` and `observable()` extension functions.

Also, `flowable()` now accepts a backpressure strategy. I set up ~`LATEST`~ `BUFFER` as the default as it seems the most sensible to me. Feel free to discuss this ;)