### PR TITLE
Rename packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Mini
-[![Release](https://jitpack.io/v/bq/mini-kotlin.svg)](https://jitpack.io/#bq/mini-kotlin)
+[![Release](https://jitpack.io/v/masmovil/mini-kotlin.svg)](https://jitpack.io/#masmovil/mini-kotlin)
 
 Mini is a minimal Flux architecture written in Kotlin that also adds a mix of useful features to build UIs fast.
 
@@ -180,19 +180,19 @@ Add the following dependencies to your app's `build.gradle`:
 dependencies {
     def mini_version = "1.0.9"
     // Minimum working dependencies
-    implementation "com.github.bq.mini-kotlin:mini-android:$mini_version"
-    kapt "com.github.bq.mini-kotlin:mini-processor:$mini_version"
+    implementation "com.github.masmovil.mini-kotlin:mini-android:$mini_version"
+    kapt "com.github.masmovil.mini-kotlin:mini-processor:$mini_version"
 
     // RxJava 2 helper libraries
-    implementation "com.github.bq.mini-kotlin:mini-rx2:$mini_version"
-    implementation "com.github.bq.mini-kotlin:mini-rx2-android:$mini_version"
+    implementation "com.github.masmovil.mini-kotlin:mini-rx2:$mini_version"
+    implementation "com.github.masmovil.mini-kotlin:mini-rx2-android:$mini_version"
 
     // Kodein helper libraries
-    implementation "com.github.bq.mini-kotlin:mini-kodein:$mini_version"
-    implementation "com.github.bq.mini-kotlin:mini-kodein-android:$mini_version"
+    implementation "com.github.masmovil.mini-kotlin:mini-kodein:$mini_version"
+    implementation "com.github.masmovil.mini-kotlin:mini-kodein-android:$mini_version"
 
     // Testing helper libraries
-    androidTestImplementation "com.github.bq.mini-kotlin:mini-testing:$mini_version"
+    androidTestImplementation "com.github.masmovil.mini-kotlin:mini-testing:$mini_version"
 }
 ```
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
     buildToolsVersion android_build_tools_version
 
     defaultConfig {
-        applicationId "com.bq.mini"
+        applicationId "com.masmovil.mini"
         minSdkVersion 21
         targetSdkVersion android_target_sdk
         versionCode android_version_code

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.gladed.androidgitversion'
 
 buildscript {
     ext {
-        kotlin_version = "1.3.50"
+        kotlin_version = "1.3.61"
 
         android_compile_sdk = 29
         android_target_sdk = 29
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath "com.android.tools.build:gradle:3.5.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.junit.platform:junit-platform-gradle-plugin:1.0.0"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:gradle:3.5.0"
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.junit.platform:junit-platform-gradle-plugin:1.0.0"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
@@ -46,7 +46,7 @@ allprojects {
     }
 
     version = mini_version
-    group = "com.bq.mini"
+    group = "com.masmovil.mini"
 
     repositories {
         jcenter()

--- a/mini-android/build.gradle
+++ b/mini-android/build.gradle
@@ -26,7 +26,7 @@ dependencies {
 
     api "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
     api "androidx.appcompat:appcompat:1.1.0"
-    api "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-alpha05"
+    api "androidx.lifecycle:lifecycle-runtime-ktx:2.2.0-rc03"
 
     testImplementation "junit:junit:4.12"
     androidTestImplementation "androidx.test:runner:1.2.0"


### PR DESCRIPTION
Changed bq with masmovil.

Tested jitpack distribution on ragnarok-android

`mini_version = "task~rename-packages-SNAPSHOT"`

```
 implementation "com.github.masmovil.mini-kotlin:mini-android:$mini_version"
    implementation "com.github.masmovil.mini-kotlin:mini-rx2:$mini_version"
    implementation "com.github.masmovil.mini-kotlin:mini-rx2-android:$mini_version"
    implementation "com.github.masmovil.mini-kotlin:mini-kodein:$mini_version"
    implementation "com.github.masmovil.mini-kotlin:mini-kodein-android:$mini_version"
    androidTestImplementation("com.github.masmovil.mini-kotlin:mini-testing:$mini_version")
```