### PR TITLE
Add support for TypedTasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,17 @@ Each ``Store`` exposes a custom `StoreCallback` though the method `observe` or a
 If you make use of the RxJava methods, you can make use of the `SubscriptionTracker` interface to keep track of the `Disposables` used on your activities and fragments.
 
 ### Tasks
-A Task is a basic object to represent an ongoing process. They should be used in the state of our `Store` to represent ongoing processes that must be represented in the UI.
+A `Task` is a basic object to represent an ongoing process. They should be used in the state of our `Store` to represent ongoing processes that must be represented in the UI.
 
+You can also use `TypedTask` to save metadata related the current task. 
+
+**IMPORTANT: Do not use TypedTask to hold values that must survive multiple task executions. Save them as a variable in the state instead.**
+
+
+### Example
 Given the example Stores and Actions explained before, the workflow will be:
 
-- View dispatch `LoginAction`.
+- View dispatches `LoginAction`.
 - Store changes his `LoginTask` status to running and call though his SessionController which will do all the async work to log in the given user.
 - View shows an Spinner when `LoginTask` is in running state.
 - The async call ends and `LoginCompleteAction` is dispatched on UI, sending a null `User` and an error state `Task` if the async work failed or a success `Task` and an `User`.
@@ -201,7 +207,7 @@ dependencies {
 You'll need to add the following snippet to your `Application`'s `onCreate` method. If you don't have it, then create it and reference it in your `AndroidManifest.xml` file:
 
 ```kotlin
-val stores = listOf<Store<*>>(...) // Here you'll set-up you store list, you can retrieve it using your preferred DI framework
+val stores = listOf<Store<*>>() // Here you'll set-up you store list, you can retrieve it using your preferred DI framework
 val dispatcher = MiniGen.newDispatcher() // Create a new dispatcher
 
 // Initialize Mini
@@ -211,9 +217,9 @@ stores.forEach { store ->
 }
 
 // Optional: add logging interceptor to log action events
-dispatcher.addInterceptor(LoggerInterceptor(stores, { tag, msg ->
+dispatcher.addInterceptor(LoggerInterceptor(stores)) { tag, msg ->
     Log.d(tag, msg)
-}))
+}
 ```
 
 ## License

--- a/mini-common/src/main/java/mini/Resource.kt
+++ b/mini-common/src/main/java/mini/Resource.kt
@@ -72,17 +72,19 @@ open class Resource<out T> @PublishedApi internal constructor(val value: Any?) {
 }
 
 /**
- * An empty resource that just abstracts asynchronous operation but with idle
+ * A resource that abstracts asynchronous operation but with idle
  * state instead of empty.
+ *
+ * It accepts temporary metadata objects as value.
  */
-class Task(value: Any?) : Resource<Unit>(value) {
+open class TypedTask<T> @PublishedApi internal constructor(value: Any?) : Resource<T>(value) {
     val isIdle: Boolean get() = isEmpty
 
     companion object {
-        fun success(): Task = Task(Unit)
-        fun idle(): Task = Task(Empty)
-        fun loading(): Task = Task(Loading<Unit>())
-        fun failure(exception: Throwable? = null): Task = Task(Failure(exception))
+        fun <T> success(value: T): TypedTask<T> = TypedTask(value)
+        fun <T> idle(): TypedTask<T> = TypedTask(Empty)
+        fun <T> loading(value: T? = null): TypedTask<T> = TypedTask(Loading(value))
+        fun <T> failure(exception: Throwable? = null): TypedTask<T> = TypedTask(Failure(exception))
     }
 
     override fun toString(): String {
@@ -91,6 +93,19 @@ class Task(value: Any?) : Resource<Unit>(value) {
             isIdle -> "Idle"
             else -> value.toString()
         }
+    }
+}
+
+/**
+ * An empty resource that just abstracts asynchronous operation but with idle
+ * state instead of empty.
+ */
+class Task(value: Any?) : TypedTask<Unit>(value) {
+    companion object {
+        fun success(): Task = Task(Unit)
+        fun idle(): Task = Task(Empty)
+        fun loading(): Task = Task(Loading<Unit>())
+        fun failure(exception: Throwable? = null): Task = Task(Failure(exception))
     }
 }
 

--- a/mini-common/src/main/java/mini/Resource.kt
+++ b/mini-common/src/main/java/mini/Resource.kt
@@ -124,7 +124,7 @@ inline fun <T> Resource<T>.onLoading(crossinline action: (data: T?) -> Unit): Re
     return this
 }
 
-inline fun Task.onIdle(crossinline action: () -> Unit): Task {
+inline fun <T> TypedTask<T>.onIdle(crossinline action: () -> Unit): TypedTask<T> {
     if (isEmpty) action()
     return this
 }


### PR DESCRIPTION
The PR adds support for Typed tasks.

A typed task can hold metadata regarding the current task, and it will only live as long as the task status is kept. Therefore these kind of tasks must never be used to store values that have to be persisted or modified along multiple task executions: save those values as variables in the store's state instead.