### PR TITLE
Add parameterized ViewModel injection via factories

### DIFF
--- a/mini-kodein-android/src/main/java/mini/kodein/android/KodeinAndroidUtils.kt
+++ b/mini-kodein-android/src/main/java/mini/kodein/android/KodeinAndroidUtils.kt
@@ -9,18 +9,25 @@ import androidx.lifecycle.ViewModelProviders
 import org.kodein.di.DKodein
 import org.kodein.di.Kodein
 import org.kodein.di.KodeinAware
+import org.kodein.di.bindings.BindingKodein
 import org.kodein.di.bindings.NoArgBindingKodein
 import org.kodein.di.direct
-import org.kodein.di.generic.bind
-import org.kodein.di.generic.instance
-import org.kodein.di.generic.instanceOrNull
-import org.kodein.di.generic.provider
+import org.kodein.di.generic.*
 
 /**
  * Binds a ViewModel to a Kotlin module, assuming that it's a provided dependency.
  */
-inline fun <reified T : ViewModel> Kodein.Builder.bindViewModel(overrides: Boolean? = null, noinline creator: NoArgBindingKodein<*>.() -> T) {
-    bind<T>(T::class.java.simpleName, overrides) with provider(creator)
+inline fun <reified VM : ViewModel> Kodein.Builder.bindViewModel(overrides: Boolean? = null,
+                                                                 noinline creator: NoArgBindingKodein<*>.() -> VM) {
+    bind<VM>(VM::class.java.simpleName, overrides) with provider(creator)
+}
+
+/**
+ * Binds a ViewModel factory to a Kotlin module in order to create new ViewModels.
+ */
+inline fun <reified VM : ViewModel, reified F : ViewModelProvider.Factory> Kodein.Builder.bindViewModelFactory(overrides: Boolean? = null,
+                                                                                                               noinline creator: BindingKodein<*>.(Any) -> F) {
+    bind<F>(VM::class.java, overrides) with factory(creator = creator)
 }
 
 /**
@@ -31,10 +38,8 @@ inline fun <reified T : ViewModel> Kodein.Builder.bindViewModel(overrides: Boole
  * if you allow creating new instances of them via [Class.newInstance] with [allowNewInstance].
  * The default is true to mimic the default behaviour of [ViewModelProviders.of].
  */
-class KodeinViewModelFactory(
-    private val injector: DKodein,
-    private val allowNewInstance: Boolean = true
-) : ViewModelProvider.Factory {
+class KodeinViewModelFactory(private val injector: DKodein,
+                             private val allowNewInstance: Boolean = true) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         return injector.instanceOrNull<ViewModel>(tag = modelClass.simpleName) as T?
@@ -65,3 +70,35 @@ inline fun <reified VM : ViewModel, T> T.viewModel(): Lazy<VM> where T : KodeinA
         ViewModelProviders.of(this, direct.instance()).get(VM::class.java)
     }
 }
+
+/**
+ * Injects a [ViewModel] into a [FragmentActivity] that implements [KodeinAware].
+ *
+ * Requires previous [ViewModelProvider.Factory] injection for the [ViewModel] via [bindViewModelFactory]
+ * to work and a [TypedViewModel] to be used.
+ */
+@MainThread
+inline fun <reified T, reified VM : TypedViewModel<T>, A> A.viewModel(params: T): Lazy<VM> where A : KodeinAware, A : FragmentActivity {
+    return lazy {
+        ViewModelProviders.of(this, direct.instance(VM::class.java, params)).get(VM::class.java)
+    }
+}
+
+/**
+ * Injects a [ViewModel] into a [Fragment] that implements [KodeinAware].
+ *
+ * Requires previous [ViewModelProvider.Factory] injection for the [ViewModel] via [bindViewModelFactory]
+ * to work and a [TypedViewModel] to be used.
+ */
+@MainThread
+inline fun <reified T, reified VM : TypedViewModel<T>, F> F.viewModel(params: T): Lazy<VM> where F : KodeinAware, F : Fragment {
+    return lazy {
+        ViewModelProviders.of(this, direct.instance(VM::class.java, params)).get(VM::class.java)
+    }
+}
+
+/**
+ * Generic [ViewModel] that adds support for adding a single [params] object to ease parameter
+ * injection.
+ */
+open class TypedViewModel<T>(private val params: T) : ViewModel()


### PR DESCRIPTION
### PR's key points
The PR adds support for injecting `ViewModel` factories and for retrieving `ViewModel`s via previously declared factories. This will ease parameterized `ViewModel`s delivery and remove some boilerplate that we use when configuring the `ViewModel`s in production code.

The added code relies in a new `TypedViewModel` that enforces passing a single `params` value to ensure type safety in the injection functions. 
I couldn't think of a better idea to do this, so if you have any other ideas (the ideal thing would be to ensure type safety while also not forcing to extend another class) feel free to propose them 😉

The final idea would be:
* Create your `ViewModel` with parameters.
* Create a `ViewModelProvider.Factory` that creates said `ViewModel`. Since the code wouldn't be especially complex, we can use something like https://github.com/radutopor/ViewModelFactory to auto-generate said factories and save some boilerplate.
* Inject the `ViewModelProvider.Factory` with `bindViewModelFactory`
* Retrieve a `ViewModel` instance with parameters using `by viewModel(parameters)`