### PR TITLE
Add safe iteration over store subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- No unreleased changes, yet!
+### Fixed
+- Fix `ConcurrentModificationException`s in store subscriptions' iteration by adding safe iteration over them.
 
 ## [1.1.2] - 2020-02-07
 ### Added

--- a/mini-common/src/main/java/mini/Store.kt
+++ b/mini-common/src/main/java/mini/Store.kt
@@ -70,8 +70,7 @@ abstract class Store<S> : Closeable {
 
     @Suppress("UNCHECKED_CAST")
     open fun initialState(): S {
-        val type = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0]
-            as Class<S>
+        val type = (javaClass.genericSuperclass as ParameterizedType).actualTypeArguments[0] as Class<S>
         try {
             val constructor = type.getDeclaredConstructor()
             constructor.isAccessible = true
@@ -85,7 +84,7 @@ abstract class Store<S> : Closeable {
         //State mutation should to happen on UI thread
         if (newState != _state) {
             _state = newState
-            listeners.forEach {
+            listeners.toList().forEach {
                 it(newState)
             }
         }


### PR DESCRIPTION
### PR's key points
The PR ensures that store subscriptions can be safely traversed and no `ConcurrentModificationException`s don't happen while emitting store changes.

Thanks to @danielceinos for the fix ;)